### PR TITLE
fix: Fixes a hyperlink on the home page

### DIFF
--- a/home/introduction.mdx
+++ b/home/introduction.mdx
@@ -10,7 +10,7 @@ Welcome to the documentation of Quack! This is the place where you'll find help,
   <Card
     title="Quick start"
     icon="forward"
-    href="getting-started/quickstart"
+    href="/getting-started/quickstart"
   >
     Get your team coding companion up and running in 5 minutes.
   </Card>

--- a/home/introduction.mdx
+++ b/home/introduction.mdx
@@ -17,7 +17,7 @@ Welcome to the documentation of Quack! This is the place where you'll find help,
   <Card
     title="Video walkthrough"
     icon="youtube"
-    href="https://www.loom.com/share/6340a7841328414f989cdcfcefd7185c?sid=61eb549b-04e3-48e7-988f-62b0ed72d77b"
+    href="https://dub.sh/quack-demo"
   >
     We've cooked some video materials to get you in-depth assistance for your setup.
   </Card>


### PR DESCRIPTION
This PR fixes the link to quickstart located on the home page, and shortens the Loom video link.

Thanks @jjerphan for spotting the hyperlink issue :pray: 