### PR TITLE
docs: Fixes the description of the GitHub star section

### DIFF
--- a/home/introduction.mdx
+++ b/home/introduction.mdx
@@ -47,7 +47,7 @@ Looking for information or assistance? We're happy to help, here are different w
     icon="star"
     href="https://github.com/quack-ai/companion"
   >
-    Build interactive features and designs to guide your users
+    Open a GitHub issue to report a bug or suggest a feature
   </Card>
   <Card
     title="Shoot us an email"


### PR DESCRIPTION
This PR fixes the description of the card suggesting to star the GitHub repo.