### PR TITLE
fix: Fixes hyperlinks in Quack vision

### DIFF
--- a/home/quack.mdx
+++ b/home/quack.mdx
@@ -62,10 +62,10 @@ From an architecture perspective now, here are all the system components:
 
 ### Client applications
 <CardGroup cols={2}>
-<Card title="Frontend platform" icon="gamepad" href="/content/components/card-group">
+<Card title="Frontend platform" icon="gamepad" href="https://app.quackai.com/">
   UI for guideline management, mostly for maintainers.
 </Card>
-<Card title="VSCode extension" icon="gamepad" href="/content/components/card-group">
+<Card title="VSCode extension" icon="gamepad" href="https://marketplace.visualstudio.com/items?itemName=quackai.quack-companion">
   Bringing code analysis and code completiong with relevant context to the developers/contributors.
 </Card>
 </CardGroup>


### PR DESCRIPTION
This PR fixes the hyperlinks on the cards at the bottom of the quack vision section.